### PR TITLE
Run lint before start

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -35,7 +35,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "lint": "eslint '*/**/*.{js,ts,tsx}' --fix"
+    "lint": "eslint \"*/**/*.{js,ts,tsx}\" --fix"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/client/package.json
+++ b/client/package.json
@@ -33,7 +33,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "lint": "eslint \"*/**/*.{js,ts,tsx}\" --fix"
+    "lint": "eslint '*/**/*.{js,ts,tsx}' --fix"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/client/package.json
+++ b/client/package.json
@@ -29,6 +29,7 @@
     "yup": "^0.32.8"
   },
   "scripts": {
+    "prestart": "npm run lint",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",

--- a/client/package.json
+++ b/client/package.json
@@ -29,6 +29,7 @@
     "yup": "^0.32.8"
   },
   "scripts": {
+    "prepare": "husky install",
     "prestart": "npm run lint",
     "start": "react-scripts start",
     "build": "react-scripts build",


### PR DESCRIPTION
### What this PR does (required):

- [x] ~restore original eslint command from starter~

- [x] include `prestart` script to automatically run `lint` script before `start`

- [x] setup included husky configs to lint before each commit

### Screenshots / Videos (required):
- N/A

### Any information needed to test this feature (required):
- Run `npm run start` and the linting will run before start

### Any issues with the current functionality (optional):
- N/A